### PR TITLE
Add of new commands : TaskEnd, TaskEndN and TaskInterval

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package contains the rtsched package for drawing GANTT charts
 (chronograms). The package can be useful for drawing real-time timing
 diagrams in LaTeX, as often needs to be done for preparing articles,
 lectures and presentation in the Real-Time Scheduling research
-community. The package depends on keyval and TikZ/PGF (version 2.10 or greater).
+community. The package depends on keyval and TikZ/PGF (versions 2.10 or greater).
 
 A more complete documentation, with a set of examples, is available in
 file rtsched-doc.pdf.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package contains the rtsched package for drawing GANTT charts
 (chronograms). The package can be useful for drawing real-time timing
 diagrams in LaTeX, as often needs to be done for preparing articles,
 lectures and presentation in the Real-Time Scheduling research
-community. The package depends on keyval and TikZ/PGF.
+community. The package depends on keyval and TikZ/PGF (version 2.10 or greater).
 
 A more complete documentation, with a set of examples, is available in
 file rtsched-doc.pdf.

--- a/rtsched-doc.tex
+++ b/rtsched-doc.tex
@@ -188,7 +188,7 @@ from periods (the so-called \emph{constrained deadline tasks}).
     \TaskNExecDelta{1}{0}{1}{4}{5}  % draws executions (highest priority) 
                                     % for 5 instances of period 4 
                                     
-    \TaskNEnd{1}{1}{4}{5}	       % draws 5 end of job execution of period 4
+    \TaskNEnd{1}{1}{4}{5}	       % draws 5 ends of job execution of period 4
 
 
                                     % draws the arrival and deadline
@@ -211,7 +211,7 @@ from periods (the so-called \emph{constrained deadline tasks}).
     \TaskNExecDelta{1}{0}{1}{4}{5}  % draws executions (highest priority) 
                                     % for 5 instances of period 4 
                                     
-    \TaskNEnd{1}{1}{4}{5}           % draws 5 end of job execution of period 4
+    \TaskNEnd{1}{1}{4}{5}           % draws 5 ends of job execution of period 4
 
    	\TaskNArrDead{2}{0}{6}{6}{3}    % draws the arrival and deadline
                                     % for 3 instances of period 6 
@@ -346,7 +346,13 @@ style. An example is in Figure~\ref{fig:resp-time} that uses command
   \label{fig:resp-time}
 \end{figure}
 
-It is sometimes usefull to represent the end of a job execution, especially when jobs are preempted. In that case, you can use the \verb+\TaskEnd{i}{t}+ command and its periodic version detailed in Table~\ref{tab:periodic_versions} that draw little circle(s) at the specified date(s). It works in the same way as \verb+\TaskArrival+ command and it is used in Figure~\ref{fig:ex1a}.
+It is sometimes usefull to represent the end of a job execution, especially when jobs are preempted. In that case, you can use the following command:
+
+\begin{verbatim}
+\TaskEnd{i}{t}
+\end{verbatim}
+
+and its periodic version detailed in Table~\ref{tab:periodic_versions} that draw little circle(s) at the specified date(s). It works in the same way as \verb+\TaskArrival+ command and its us is shown in Figure~\ref{fig:ex1a}.
 
 
 
@@ -633,6 +639,65 @@ following command:
   \caption{Priority Inheritance example}
   \label{fig:ex4}
 \end{figure}
+
+
+\subsection{Jitter}
+
+
+Jitter is often represented as an interval drawned by an horizontal double arrowhead. As shown in the Figure~\ref{fig:interval}, you can define jitter or any other interval with the following command:
+
+\begin{verbatim}
+\TaskInterval{i}{t1}{t2}{label}
+\end{verbatim}
+
+This command draws an horizontal double arrowhead for the \texttt{i}-th task from \texttt{t1} to \texttt{t2} with the specified \texttt{label} in the middle.
+
+\begin{figure}[!htbp]
+  \centering
+  \begin{RTGrid}[nogrid=1, nosymbols=1 ,nonumbers=1]{3}{20}
+  
+    \RowLabel{1}{$\tau_i$}
+    \TaskArrival{1}{0}            
+    \TaskExecution{1}{1}{4}             
+    \TaskDeadline{1}{7}           
+
+    \RowLabel{2}{msg}
+    \TaskArrival{2}{0}              
+    \TaskExecution{2}{4}{6}             
+    \TaskDeadline{2}{8}            
+    \TaskInterval{2}{0}{4}{$J_m$}  % draws an interval between date 0 and 4 for task 2 with a label J_m 
+
+    \RowLabel{3}{$\tau_j$}
+    \TaskArrival{3}{0}             
+    \TaskExecution{3}{6}{9}             
+    \TaskDeadline{3}{10}          
+    \TaskInterval{3}{0}{6}{$J_j$} % draws an interval between date 0 and 6 for task 3 with a label J_j 
+  \end{RTGrid}  
+\begin{verbatim}
+  \begin{RTGrid}[nogrid=1, nosymbols=1 ,nonumbers=1]{3}{20}
+  
+    \RowLabel{1}{$\tau_i$}
+    \TaskArrival{1}{0}            
+    \TaskExecution{1}{1}{4}             
+    \TaskDeadline{1}{7}           
+
+    \RowLabel{2}{msg}
+    \TaskArrival{2}{0}              
+    \TaskExecution{2}{4}{6}             
+    \TaskDeadline{2}{8}            
+    \TaskInterval{2}{0}{4}{$J_m$}  % draws an interval between date 0 and 4 for task 2 with a label J_m 
+
+    \RowLabel{3}{$\tau_j$}
+    \TaskArrival{3}{0}             
+    \TaskExecution{3}{6}{9}             
+    \TaskDeadline{3}{10}          
+    \TaskInterval{3}{0}{6}{$J_j$} % draws an interval between date 0 and 6 for task 3 with a label J_j 
+  \end{RTGrid}  
+\end{verbatim}
+  \caption{Example with TaskInterval used to represent jitters}
+  \label{fig:interval}
+\end{figure}
+
 
 \end{document}
 %%% Local Variables: 

--- a/rtsched-doc.tex
+++ b/rtsched-doc.tex
@@ -18,8 +18,8 @@ In this document, I give an overview of the \texttt{rtsched} \LaTeX
 package, which can be used to easily draw chronograms (GANTT charts).
 These diagrams are quite common in real-time scheduling research.
 
-
-The package depends on keyval and TikZ/PGF (pgf version 2.10 or greater), both widely available on any \TeX distribution.
+The package depends on keyval and TikZ/PGF (pgf version 2.10 or greater), both widely
+available on any \TeX distribution.
 
 The drawing capabilities are completely based on TikZ. Thus, you can compile
  a document that uses \texttt{rtsched} package with modern tools producing pdf document
@@ -346,13 +346,13 @@ style. An example is in Figure~\ref{fig:resp-time} that uses command
   \label{fig:resp-time}
 \end{figure}
 
-It is sometimes usefull to represent the end of a job execution, especially when jobs are preempted. In that case, you can use the following command:
+It is sometimes useful to represent the end of a job execution, especially to distinguish it from preemption. In that case, you can use the following command :
 
 \begin{verbatim}
 \TaskEnd{i}{t}
 \end{verbatim}
 
-and its periodic version detailed in Table~\ref{tab:periodic_versions} that draw little circle(s) at the specified date(s). It works in the same way as \verb+\TaskArrival+ command and its us is shown in Figure~\ref{fig:ex1a}.
+and its periodic version detailed in Table~\ref{tab:periodic_versions} that draw little circle(s) at the specified date(s). It works in the same way as \verb+\TaskArrival+ command as shown in Figure~\ref{fig:ex1a}.
 
 
 
@@ -644,7 +644,7 @@ following command:
 \subsection{Jitter}
 
 
-Jitter is often represented as an interval drawned by an horizontal double arrowhead. As shown in the Figure~\ref{fig:interval}, you can define jitter or any other interval with the following command:
+Jitter is often represented as an interval drawn by an horizontal double-headed arrow. As shown in the Figure~\ref{fig:interval}, you can define jitter or any other interval with the following command :
 
 \begin{verbatim}
 \TaskInterval{i}{t1}{t2}{label}

--- a/rtsched-doc.tex
+++ b/rtsched-doc.tex
@@ -18,7 +18,7 @@ In this document, I give an overview of the \texttt{rtsched} \LaTeX
 package, which can be used to easily draw chronograms (GANTT charts).
 These diagrams are quite common in real-time scheduling research.
 
-The package depends on keyval and TikZ/PGF, both widely
+The package depends on keyval and TikZ/PGF (pgf version 2.10 or greater), both widely
 available on any \TeX distribution.
 
 The drawing capabilities are completely based on TikZ. Thus, you can compile
@@ -88,6 +88,8 @@ Figure \ref{fig:ex1a}. Available periodic versions of the commands can be found 
  \verb+\TaskDeadline{i}{t}+ & \verb+\TaskNDeadline{i}{t}{p}{n}+ \\
  \verb+\TaskArrDeadl{i}{t}{reld}+ & \verb+\TaskNArrDeadl{i}{t}{reld}{p}{n}+  \\
  \verb+\TaskExecDelta{i}{t}{delta}+ & \verb+\TaskNExecDelta{i}{t}{delta}{p}{n}+\\
+ \verb+\TaskEnd{i}{t}+ & \verb+\TaskNEnd{i}{t}{p}{n}+\\
+
   \hline
 \end{tabular}
 \caption{Table of periodic commands where p stands for the period and n for the number of instances}
@@ -185,6 +187,9 @@ from periods (the so-called \emph{constrained deadline tasks}).
     \TaskNArrDead{1}{0}{4}{4}{5}    % draws the arrivals and deadlines
     \TaskNExecDelta{1}{0}{1}{4}{5}  % draws executions (highest priority) 
                                     % for 5 instances of period 4 
+                                    
+    \TaskNEnd{1}{1}{4}{5}	       % draws 5 end of job execution of period 4
+
 
                                     % draws the arrival and deadline
     \TaskNArrDead{2}{0}{6}{6}{3}    % for 3 instances of period 6 
@@ -193,7 +198,10 @@ from periods (the so-called \emph{constrained deadline tasks}).
     \TaskExecution{2}{1}{4}
     \TaskExecution{2}{6}{8}
     \TaskExecution{2}{9}{10}
-    \TaskExecution{2}{13}{16}    
+    \TaskExecution{2}{13}{16} 
+    \TaskEnd{2}{4}
+    \TaskEnd{2}{10}
+    \TaskEnd{2}{16}   
   \end{RTGrid}
 
 \begin{verbatim}
@@ -202,15 +210,21 @@ from periods (the so-called \emph{constrained deadline tasks}).
     \TaskNArrDead{1}{0}{4}{4}{5}    % draws the arrivals and deadlines
     \TaskNExecDelta{1}{0}{1}{4}{5}  % draws executions (highest priority) 
                                     % for 5 instances of period 4 
+                                    
+    \TaskNEnd{1}{1}{4}{5}           % draws 5 end of job execution of period 4
 
    	\TaskNArrDead{2}{0}{6}{6}{3}    % draws the arrival and deadline
                                     % for 3 instances of period 6 
+	    
     
     % no simple formula for lowest priority, sorry!
     \TaskExecution{2}{1}{4}
     \TaskExecution{2}{6}{8}
     \TaskExecution{2}{9}{10}
-    \TaskExecution{2}{13}{16}    
+    \TaskExecution{2}{13}{16} 
+    \TaskEnd{2}{4}
+    \TaskEnd{2}{10}
+    \TaskEnd{2}{16}  
   \end{RTGrid}
 \end{verbatim}
   \caption{Using periodic commands to avoid repetitions}
@@ -288,7 +302,7 @@ It is also possible to visualise preempted tasks with a hatched fill
 style. An example is in Figure~\ref{fig:resp-time} that uses command
 \texttt{TaskRespTime}. 
 
-\begin{figure}
+\begin{figure}[!htbp]
   \centering
   \begin{RTGrid}{2}{20}
   
@@ -331,6 +345,10 @@ style. An example is in Figure~\ref{fig:resp-time} that uses command
   \caption{Example with TaskRespTime}
   \label{fig:resp-time}
 \end{figure}
+
+It is sometimes usefull to represent the end of a job execution, especially when jobs are preempted. In that case, you can use the \verb+\TaskEnd{i}{t}+ command and its periodic version detailed in Table~\ref{tab:periodic_versions} that draw little circle(s) at the specified date(s). It works in the same way as \verb+\TaskArrival+ command and it is used in Figure~\ref{fig:ex1a}.
+
+
 
 
 \subsection{Controlling visualization}
@@ -535,8 +553,8 @@ to highlight a portion of the schedule with \texttt{RTBox}:
 
 Notice that the order with which the objects are drawn is exactly the
 same as the order in which they are specified in the code, excepted 
-for horizontal axes, arrivals and deadlines that are always drawn on the foreground.
- For example, in Figure \ref{fig:ex3a}, the executions of all the tasks are
+for horizontal axes, arrivals, deadlines and end of job execution that are always drawn on the foreground. 
+For example, in Figure \ref{fig:ex3a}, the executions of all the tasks are
 drawn on top of the box. You can try to move the \texttt{RTBox}
 command at the end to see what happens.
 
@@ -568,7 +586,7 @@ following command:
 \TaskExecution[color=white,execlabel=S]{3}{4}{5}
 \end{verbatim}
 
-\begin{figure}
+\begin{figure}[!htbp]
   \centering
   \begin{RTGrid}[width=12cm]{3}{25}
     \TaskArrDead{3}{0}{20}

--- a/rtsched-doc.tex
+++ b/rtsched-doc.tex
@@ -18,7 +18,7 @@ In this document, I give an overview of the \texttt{rtsched} \LaTeX
 package, which can be used to easily draw chronograms (GANTT charts).
 These diagrams are quite common in real-time scheduling research.
 
-The package depends on keyval and TikZ/PGF, both widely
+The package depends on keyval and TikZ/PGF (versions 2.10 or greater), both widely
 available on any \TeX distribution.
 
 The drawing capabilities are completely based on TikZ. Thus, you can compile

--- a/rtsched-doc.tex
+++ b/rtsched-doc.tex
@@ -650,7 +650,7 @@ Jitter is often represented as an interval drawn by an horizontal double-headed 
 \TaskInterval{i}{t1}{t2}{label}
 \end{verbatim}
 
-This command draws an horizontal double arrowhead for the \texttt{i}-th task from \texttt{t1} to \texttt{t2} with the specified \texttt{label} in the middle.
+This command draws an horizontal double-headed arrow for the \texttt{i}-th task from \texttt{t1} to \texttt{t2} with the specified \texttt{label} in the middle.
 
 \begin{figure}[!htbp]
   \centering

--- a/rtsched.sty
+++ b/rtsched.sty
@@ -28,7 +28,21 @@
 \usetikzlibrary{shadows, patterns}
 \RequirePackage{keyval}
 \newcommand\rtfont{\usefont{T1}{phv}{m}{n}}
+\@ifpackagelater{pgf}{2008/01/15}
+{
+ %pgf package date is 2008/01/15 or later
+}
+{
+ %pgf package date is older than 2008/01/15
+\PackageError{rtsched}{%
+rtsched requires version 2.10 of pgf or greater\MessageBreak
 
+}{%
+Please update pgf to version 2.10 minimum!\MessageBreak
+\space \space Try typing \space \protect\pgfversion
+\space to print your current version of pgf.
+}
+}
 
 %%
 %% These can be changed at any time
@@ -510,6 +524,37 @@
 \@RTExecDefaultValues
 
 }
+
+% TaskEnd
+% Task end: draws a circle when the job terminates
+% par 1: task number from 1 to n
+% par 2: slot number from 0 to l-1
+\newcommand{\TaskEnd}[3][nocommand=1]{%
+  \setkeys{RT}{#1}%
+  \@compute@yy{#2}
+  \@compute@xx{#3}
+  \yyy = \yy \advance \yyy by 2\sy%
+  \begin{pgfonlayer}{foreground} 
+  \draw[fill] (\xx,\yy) circle (1.5pt);
+  \end{pgfonlayer}
+  \@RTExecDefaultValues%
+}
+
+%
+% TaskNEnd
+% Task ends: draws periodically a circle when the job terminates
+% par 1  : task number from 1 to n
+% par 2  : slot number from 0 to l-1
+% par 3  : period
+% par 4  : number of instances
+\newcommand{\TaskNEnd}[5][nocommand=1]{%
+ \foreach \instance [evaluate = \instance as \activation using (#3 + \instance * #4)] in {0,...,\numexpr #5-1}{
+ \TaskEnd[#1]{#2}{\activation}{#4}
+ }
+}
+
+
+
 %% %
 % % par 1: task
 % % par 2: first instant (arrival)
@@ -648,6 +693,12 @@
   }  
   \renewcommand<>{\TaskInterval}[5][nocommand=1]{
     \only#6{\beameroriginal{\TaskInterval}[#1]{#2}{#3}{#4}{#5}}
+  }
+  \renewcommand<>{\TaskEnd}[3][nocommand=1]{
+    \only#4{\beameroriginal{\TaskEnd}[#1]{#2}{#3}}
+  }
+  \renewcommand<>{\TaskNEnd}[5][nocommand=1]{
+    \only#6{\beameroriginal{\TaskNEnd}[#1]{#2}{#3}{#4}{#5}}
   }
 }
 {\typeout{beamer not loaded}}

--- a/rtsched.sty
+++ b/rtsched.sty
@@ -489,7 +489,28 @@
 }
 
 
+%
+% TaskMargin
+% par 1: task
+% par 2: start time
+% par 3: finish time
+\newcommand{\TaskMargin}[4][nocommand=1]{
+\setkeys{RT}{#1}
+\@compute@yy{#2}
+\@compute@xx{#3}
+\@compute@xxx{#4}
+\advance \yy by .5\sy
+\draw [\RTLineColor, thick, \RTArrowStyle-\RTArrowStyle] (\xx,\yy) -- (\xxx,\yy);
+\advance \xx by \xxx \xx = .5\xx
+%\advance \yy by .5\RTExecHeight\sy
+\draw (\xx,\yy) node[above,font=\rtfont] {\RTNumberLabelSize \RTExecLabel};%\RTNumberLabelSize
+\@RTExecDefaultValues
 
+ % \advance \xx by \xxx \xx = .5\xx
+  %\advance \yy by .5\RTExecHeight\sy
+  %\draw (\xx,\yy) node[font=\rtfont] {\RTNumberLabelSize \RTExecLabel};%\RTNumberLabelSize
+
+}
 %% %
 % % par 1: task
 % % par 2: first instant (arrival)
@@ -626,6 +647,9 @@
   \renewcommand<>{\FLine}[5][nocommand=1]{
     \only#6{\beameroriginal{\FLine}[#1]{#2}{#3}{#4}{#5}}
   }  
+  \renewcommand<>{\TaskMargin}[4][nocommand=1]{
+    \only#5{\beameroriginal{\TaskMargin}[#1]{#2}{#3}{#4}}
+  }
 }
 {\typeout{beamer not loaded}}
 

--- a/rtsched.sty
+++ b/rtsched.sty
@@ -490,11 +490,13 @@
 
 
 %
-% TaskMargin
+% TaskInterval : specify an interval with an horizontal double arrow
 % par 1: task
 % par 2: start time
 % par 3: finish time
-\newcommand{\TaskMargin}[4][nocommand=1]{
+% par 4: label
+
+\newcommand{\TaskInterval}[5][nocommand=1]{
 \setkeys{RT}{#1}
 \@compute@yy{#2}
 \@compute@xx{#3}
@@ -503,12 +505,9 @@
 \draw [\RTLineColor, thick, \RTArrowStyle-\RTArrowStyle] (\xx,\yy) -- (\xxx,\yy);
 \advance \xx by \xxx \xx = .5\xx
 %\advance \yy by .5\RTExecHeight\sy
-\draw (\xx,\yy) node[above,font=\rtfont] {\RTNumberLabelSize \RTExecLabel};%\RTNumberLabelSize
-\@RTExecDefaultValues
+\draw (\xx,\yy) node[above,font=\rtfont] {\RTTaskLabelSize #5};%
 
- % \advance \xx by \xxx \xx = .5\xx
-  %\advance \yy by .5\RTExecHeight\sy
-  %\draw (\xx,\yy) node[font=\rtfont] {\RTNumberLabelSize \RTExecLabel};%\RTNumberLabelSize
+\@RTExecDefaultValues
 
 }
 %% %
@@ -647,8 +646,8 @@
   \renewcommand<>{\FLine}[5][nocommand=1]{
     \only#6{\beameroriginal{\FLine}[#1]{#2}{#3}{#4}{#5}}
   }  
-  \renewcommand<>{\TaskMargin}[4][nocommand=1]{
-    \only#5{\beameroriginal{\TaskMargin}[#1]{#2}{#3}{#4}}
+  \renewcommand<>{\TaskInterval}[5][nocommand=1]{
+    \only#6{\beameroriginal{\TaskInterval}[#1]{#2}{#3}{#4}{#5}}
   }
 }
 {\typeout{beamer not loaded}}


### PR DESCRIPTION
- Add of TaskEnd command to define the jobs execution end and its periodic version TaskNEnd. 
- Add of TaskInterval command to define an interval such that jitter by drawing an horizontal double-headed arrow
- Documentation updated with these commands and warning that pgf version 2.10 minimum is required 
