### PR TITLE
Support for TikZ patterns to illustrate task executions

### DIFF
--- a/rtsched-doc.tex
+++ b/rtsched-doc.tex
@@ -4,9 +4,9 @@
 \usepackage{url}
 
 
-\title{The \texttt{rtsched} package for \LaTeX \\ (version 2.0)}
+\title{The \texttt{rtsched} package for \LaTeX \\ (version 2.0.1)}
 \author{Giuseppe Lipari}
-
+\date{December 2, 2024}
 \begin{document}
 
 \maketitle
@@ -425,7 +425,9 @@ smaller. Notice that you can directly specify colors using the TikZ
     %% the next two boxes are filled with red instead of gray
     \TaskExecution[color=red]{2}{6}{8}
     \TaskExecution[color=red!50]{2}{9}{10}
-    \TaskExecution{2}{13}{16}        
+    %% the last box is filled with an orange horizontal lines pattern
+    %% from the TikZ patterns library
+    \TaskExecution[pattern={horizontal lines},pattern color=orange]{2}{13}{16}     
   \end{RTGrid}
 
 \begin{verbatim}
@@ -443,7 +445,9 @@ smaller. Notice that you can directly specify colors using the TikZ
     %% the next two boxes are filled with red instead of gray
     \TaskExecution[color=red]{2}{6}{8}
     \TaskExecution[color=red]{2}{9}{10}
-    \TaskExecution{2}{13}{16}        
+    %% the last box is filled with an orange horizontal lines pattern
+    %% from the TikZ patterns library
+    \TaskExecution[pattern={horizontal lines},pattern color=orange]{2}{13}{16}        
   \end{RTGrid}
 \end{verbatim}
   \caption{Different symbols (with \textbackslash Large size), no numbers, a different
@@ -609,7 +613,7 @@ following command:
     \TaskArrDead{3}{0}{20}
     \TaskExecution{3}{0}{2}
     \TaskLock{3}{2}{S}
-    \TaskExecution[color=red,execlabel=S,pattern=dots]{3}{2}{3}
+    \TaskExecution[color=white,execlabel=S]{3}{2}{3}
     \TaskArrDead{1}{3}{9}  
     \TaskExecution{1}{3}{4}
     \TaskLock{1}{4}{S}

--- a/rtsched-doc.tex
+++ b/rtsched-doc.tex
@@ -608,7 +608,7 @@ following command:
     \TaskArrDead{3}{0}{20}
     \TaskExecution{3}{0}{2}
     \TaskLock{3}{2}{S}
-    \TaskExecution[color=white,execlabel=S]{3}{2}{3}
+    \TaskExecution[color=red,execlabel=S,pattern=dots]{3}{2}{3}
     \TaskArrDead{1}{3}{9}  
     \TaskExecution{1}{3}{4}
     \TaskLock{1}{4}{S}

--- a/rtsched-doc.tex
+++ b/rtsched-doc.tex
@@ -3,6 +3,7 @@
 \usepackage{rtsched}
 \usepackage{url}
 
+
 \title{The \texttt{rtsched} package for \LaTeX \\ (version 2.0)}
 \author{Giuseppe Lipari}
 

--- a/rtsched.sty
+++ b/rtsched.sty
@@ -24,7 +24,7 @@
 \typeout{Version 2.0.1}
 
 \RequirePackage{tikz}
-\usetikzlibrary{shadows, patterns}
+\usetikzlibrary{shadows, patterns,,patterns.meta}
 \RequirePackage{keyval}
 \newcommand\rtfont{\usefont{T1}{phv}{m}{n}}
 \@ifpackagelater{pgf}{2008/01/15}
@@ -55,6 +55,8 @@ Please update pgf to version 2.10 minimum!\MessageBreak
 \def\RTDefNumberOffset{0}
 \def\RTDefTaskFill{solid}
 \def\RTDefTaskColor{gray}
+\def\RTDefTaskPattern{}
+\def\RTDefTaskPatternColor{}
 \def\RTDefLineColor{black}
 \def\RTDefXScale{1}
 \def\RTDefWriteSymbols{0}
@@ -72,6 +74,8 @@ Please update pgf to version 2.10 minimum!\MessageBreak
 \def\RTDefEndInstance{0} 
 
 \def\RTExecLabel{\ }
+\def\RTTaskPattern{}
+\def\RTTaskPatternColor{}
 \def\RTTaskSymbol{\RTDefTaskSymbol}
 \def\RTTaskFill{\RTDefTaskFill}
 \def\RTTaskColor{\RTDefTaskColor}
@@ -93,6 +97,8 @@ Please update pgf to version 2.10 minimum!\MessageBreak
 \define@key{RT}{labelsize}[\normalsize]{\def\RTTaskLabelSize{#1}}
 \define@key{RT}{numbersize}[\normalsize]{\def\RTNumberLabelSize{#1}}
 \define@key{RT}{color}[\RTDefTaskColor]{\def\RTTaskColor{#1}}
+\define@key{RT}{pattern}[]{\def\RTTaskPattern{#1}}
+\define@key{RT}{pattern color}[]{\def\RTTaskPatternColor{#1}}
 \define@key{RT}{linecolor}[\RTDefLineColor]{\def\RTLineColor{#1}}
 \define@key{RT}{execlabel}[\ ]{\def\RTExecLabel{#1}}
 \define@key{RT}{fillstyle}[\RTDefTaskFill]{\def\RTTaskFill{#1}}
@@ -222,6 +228,8 @@ Please update pgf to version 2.10 minimum!\MessageBreak
   \setkeys{RT}{execlabel}%
   \setkeys{RT}{linecolor}%
   \setkeys{RT}{end}%
+  \setkeys{RT}{pattern}%
+  \setkeys{RT}{pattern color}%
 }
 
 \def\RTGridEnd{
@@ -398,8 +406,19 @@ Please update pgf to version 2.10 minimum!\MessageBreak
   \@compute@xx{#3}
   \yyy = \yy \advance \yyy by \RTExecHeight\sy
   \@compute@xxx{#4}
-  \draw [fill=\RTTaskColor,\RTTaskFill,draw=\RTLineColor, thick] (\xx,\yy) rectangle (\xxx,\yyy);
-  \advance \xx by \xxx \xx = .5\xx
+
+  \ifx\RTTaskPattern\@empty
+    \ifx\RTTaskPatternColor\@empty
+      \def\RTTaskPatternColorOption{}
+    \fi
+  \else
+    \def\RTTaskPatternColorOption{pattern color=\RTTaskPatternColor}
+  \fi
+  \typeout{Valeur de la variable RTTaskPattern : '\RTTaskPattern'}
+
+\edef\RTTaskExecOptions{fill=\RTTaskColor,\RTTaskFill,draw=\RTLineColor, thick, pattern={\RTTaskPattern}, \RTTaskPatternColorOption}
+\expandafter\draw\expandafter[\RTTaskExecOptions] (\xx,\yy) rectangle (\xxx,\yyy);
+  \advance \xx by \xxx \xx = .5\xx!!
   \advance \yy by .5\RTExecHeight\sy
   \draw (\xx,\yy) node[font=\rtfont] {\RTNumberLabelSize \RTExecLabel};%\RTNumberLabelSize
    \if\RTEndInstance\RTDefEndInstance

--- a/rtsched.sty
+++ b/rtsched.sty
@@ -422,7 +422,7 @@ Please update pgf to version 2.10 minimum!\MessageBreak
   
   \ifx\RTTaskPattern\@empty
   \else
-    \edef\RTTaskExecOptions{\RTTaskExecOptions, pattern=\RTTaskPattern, \RTTaskPatternColorOption}
+    \edef\RTTaskExecOptions{\RTTaskExecOptions, pattern={\RTTaskPattern}, \RTTaskPatternColorOption}
   \fi
 
 \expandafter\draw\expandafter[\RTTaskExecOptions] (\xx,\yy) rectangle (\xxx,\yyy);
@@ -655,7 +655,7 @@ Please update pgf to version 2.10 minimum!\MessageBreak
   
   \ifx\RTTaskPattern\@empty
   \else
-    \edef\RTTaskExecOptions{\RTTaskExecOptions, pattern=\RTTaskPattern, \RTTaskPatternColorOption}
+    \edef\RTTaskExecOptions{\RTTaskExecOptions, pattern={\RTTaskPattern}, \RTTaskPatternColorOption}
   \fi
 
   \expandafter\draw\expandafter[\RTTaskExecOptions] (\xx,\yy) rectangle (\xxx,\yyy);  

--- a/rtsched.sty
+++ b/rtsched.sty
@@ -20,11 +20,11 @@
 \typeout{'rtsched' style for Latex and TikZ/PGF}
 \typeout{Easily draw real-time schedules in TeX/Latex.}
 \typeout{(c) 2005, Giuseppe Lipari, Lille, France (g.lipari@univ-lille.fr)}
-\typeout{(c) 2015, Antoine Bertout (bertout.antoine@gmail.com)}
+\typeout{(c) 2015, Antoine Bertout, Poitiers, France (antoine.bertout@univ-poitiers.fr)}
 \typeout{Version 2.0.1}
 
 \RequirePackage{tikz}
-\usetikzlibrary{shadows, patterns,,patterns.meta}
+\usetikzlibrary{shadows, patterns,patterns.meta}
 \RequirePackage{keyval}
 \newcommand\rtfont{\usefont{T1}{phv}{m}{n}}
 \@ifpackagelater{pgf}{2008/01/15}

--- a/rtsched.sty
+++ b/rtsched.sty
@@ -639,16 +639,36 @@ Please update pgf to version 2.10 minimum!\MessageBreak
   \yyy = \yy \advance \yyy by \RTExecHeight \sy
   %\@compute@xxx{#4}
   \xxx = \xx \advance \xxx by #4\sx
-   \draw [fill=\RTTaskColor,\RTTaskFill,draw=\RTLineColor, thick] (\xx,\yy) rectangle (\xxx,\yyy);
+  
+  \ifx\RTTaskPatternColor\@empty
+    \def\RTTaskPatternColorOption{}
+  \else
+    \def\RTTaskPatternColorOption{pattern color=\RTTaskPatternColor}
+  \fi
+
+  \edef\RTTaskExecOptions{
+    fill=\RTTaskColor,
+    \RTTaskFill,
+    draw=\RTLineColor,
+    thick
+  }
+  
+  \ifx\RTTaskPattern\@empty
+  \else
+    \edef\RTTaskExecOptions{\RTTaskExecOptions, pattern=\RTTaskPattern, \RTTaskPatternColorOption}
+  \fi
+
+  \expandafter\draw\expandafter[\RTTaskExecOptions] (\xx,\yy) rectangle (\xxx,\yyy);  
+  
   \advance \xx by \xxx \xx = .5\xx
-   \draw (\xx,\yy) node[above, font=\rtfont] {\RTTaskLabelSize \RTExecLabel}; %\RTNumberLabelSize
-   \if\RTEndInstance\RTDefEndInstance
-     \relax
-   \else 
-     \begin{pgfonlayer}{foreground} 
-       \draw[\RTLineColor, fill] (\xxx,\yyy) circle (1.5pt);
-     \end{pgfonlayer}
-   \fi
+  \draw (\xx,\yy) node[above, font=\rtfont] {\RTTaskLabelSize \RTExecLabel}; %\RTNumberLabelSize
+  \if\RTEndInstance\RTDefEndInstance
+    \relax
+  \else 
+    \begin{pgfonlayer}{foreground} 
+      \draw[\RTLineColor, fill] (\xxx,\yyy) circle (1.5pt);
+    \end{pgfonlayer}
+  \fi
   \@RTExecDefaultValues
 }
 

--- a/rtsched.sty
+++ b/rtsched.sty
@@ -24,7 +24,7 @@
 \typeout{Version 2.0.1}
 
 \RequirePackage{tikz}
-\usetikzlibrary{shadows, patterns,patterns.meta}
+\usetikzlibrary{shadows, patterns, patterns.meta}
 \RequirePackage{keyval}
 \newcommand\rtfont{\usefont{T1}{phv}{m}{n}}
 \@ifpackagelater{pgf}{2008/01/15}
@@ -407,16 +407,24 @@ Please update pgf to version 2.10 minimum!\MessageBreak
   \yyy = \yy \advance \yyy by \RTExecHeight\sy
   \@compute@xxx{#4}
 
-  \ifx\RTTaskPattern\@empty
-    \ifx\RTTaskPatternColor\@empty
-      \def\RTTaskPatternColorOption{}
-    \fi
+  \ifx\RTTaskPatternColor\@empty
+    \def\RTTaskPatternColorOption{}
   \else
     \def\RTTaskPatternColorOption{pattern color=\RTTaskPatternColor}
   \fi
-  \typeout{Valeur de la variable RTTaskPattern : '\RTTaskPattern'}
 
-\edef\RTTaskExecOptions{fill=\RTTaskColor,\RTTaskFill,draw=\RTLineColor, thick, pattern={\RTTaskPattern}, \RTTaskPatternColorOption}
+  \edef\RTTaskExecOptions{
+    fill=\RTTaskColor,
+    \RTTaskFill,
+    draw=\RTLineColor,
+    thick
+  }
+  
+  \ifx\RTTaskPattern\@empty
+  \else
+    \edef\RTTaskExecOptions{\RTTaskExecOptions, pattern=\RTTaskPattern, \RTTaskPatternColorOption}
+  \fi
+
 \expandafter\draw\expandafter[\RTTaskExecOptions] (\xx,\yy) rectangle (\xxx,\yyy);
   \advance \xx by \xxx \xx = .5\xx!!
   \advance \yy by .5\RTExecHeight\sy


### PR DESCRIPTION
Adds support for the pattern and pattern color options from the [Tikz Patterns Library](https://tikz.dev/library-patterns) to customize motifs applied to task executions.  Modified Commands:
- TaskExecution
- TaskExecDelta

Example with rendering: 

```latex

\begin{RTGrid}[width=8cm,symbol=\pi,nonumbers=1,labelsize=\small]{2}{10}
  \TaskExecDelta[execlabel=$\tau$,pattern={horizontal lines},pattern color=red]{1}{3}{4}
  \TaskExecution[pattern={Lines[angle=-90, distance=2pt]},pattern color=orange]{2}{2}{5}        
\end{RTGrid}
  
  ```
  ![rtsched_pattern](https://github.com/user-attachments/assets/d3ef674a-b193-4bc4-a2e4-0370e700e08d)
  
  
A single task execution in the documentation is now illustrated with a pattern, accompanied by its comment.